### PR TITLE
Fix search using the address bar

### DIFF
--- a/application/basilisk/base/content/urlbarBindings.xml
+++ b/application/basilisk/base/content/urlbarBindings.xml
@@ -606,8 +606,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             typeof(engineOrEngineName) == "string" ?
               Services.search.getEngineByName(engineOrEngineName) :
               engineOrEngineName;
-          let isOneOff = this.popup.oneOffSearchButtons
-              .maybeRecordTelemetry(event, openUILinkWhere, openUILinkParams);
           // Infer the type of the event which triggered the search.
           let eventType = "unknown";
           if (event instanceof KeyboardEvent) {
@@ -617,7 +615,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
           }
           // Augment the search action details object.
           let details = searchActionDetails || {};
-          details.isOneOff = isOneOff;
           details.type = eventType;
 
           BrowserSearch.recordSearchInTelemetry(engine, "urlbar", details);

--- a/application/basilisk/components/preferences/advanced.js
+++ b/application/basilisk/components/preferences/advanced.js
@@ -41,9 +41,9 @@ var gAdvancedPane = {
     this.updateReadPrefs();
 #endif
     this.updateOfflineApps();
-    this.initTelemetry();
+    //this.initTelemetry();
 #ifdef MOZ_TELEMETRY_REPORTING
-    this.initSubmitHealthReport();
+    //this.initSubmitHealthReport();
 #endif
     this.updateOnScreenKeyboardVisibility();
     this.updateCacheSizeInputField();

--- a/application/basilisk/components/search/content/search.xml
+++ b/application/basilisk/components/search/content/search.xml
@@ -435,7 +435,6 @@
             isSuggestion: (!aOneOff && searchDetails),
             selection: searchDetails
           };
-          BrowserSearch.recordSearchInTelemetry(engine, "searchbar", details);
           // null parameter below specifies HTML response for search
           let params = {
             postData: submission.postData,


### PR DESCRIPTION
Removes calls to unimplemented (presumably removed?) functions. Also includes a fix for the Advanced Tab in Settings, though it already works fine with your mozconfig.